### PR TITLE
Use variadic template args to support more kinds of containers

### DIFF
--- a/cpp/src/lib/cucumber-messages/cucumber/messages/utils.hpp
+++ b/cpp/src/lib/cucumber-messages/cucumber/messages/utils.hpp
@@ -15,15 +15,15 @@ using json = nlohmann::json;
 namespace detail {
 
 template <
-    template <typename> class Container,
-    template <typename> class Other,
+    template <typename ...> class Container,
+    template <typename ...> class Other,
     typename T
 >
 std::is_same<Container<T>, Other<T>>
 test_is_container(Other<T>*);
 
 template <
-    template <typename> class Container,
+    template <typename ...> class Container,
     typename T
 >
 std::false_type test_is_container(T*);
@@ -31,7 +31,7 @@ std::false_type test_is_container(T*);
 } // namespace detail
 
 template <
-    template <typename> class C,
+    template <typename ...> class C,
     typename T
 >
 using is_container = decltype(
@@ -39,7 +39,7 @@ using is_container = decltype(
 );
 
 template <
-    template <typename> class C,
+    template <typename ...> class C,
     typename T
 >
 inline


### PR DESCRIPTION
## What is the goal of this PR?
Update `constexpr`'s to use variadic templates  for clang compatibility.

## What are the changes implemented in this PR?
* Update `constexpr`'s to use variadic templates  for clang compatibility.